### PR TITLE
Fix the accordion collapse transition glitch

### DIFF
--- a/resources/views/components/katana/accordion/item.blade.php
+++ b/resources/views/components/katana/accordion/item.blade.php
@@ -35,12 +35,13 @@
             @endif
         </span>
     </button>
-    <div 
-        x-show="isOpen(id)" 
-        x-collapse 
+    <div
+        x-show="isOpen(id)"
+        x-collapse
         x-cloak
-        {{ $attributes->twMergeFor('content', 'px-3 pb-4 pt-0 text-sm text-foreground/70') }}
     >
-        {{ $slot }}
+        <div {{ $attributes->twMergeFor('content', 'px-3 pb-4 pt-0 text-sm text-foreground/70') }}>
+            {{ $slot }}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
There is a problem with x-collapse when it not wrapped with div, it make the animation glitch like the height is not doing correctly.
Here is the before and after.

https://github.com/user-attachments/assets/21c888f5-c8a2-48c6-860c-fcd1a9df7198
