### PR TITLE
fix(avatar-upload): fix Croppie init on hidden element + 1:1 crop output

### DIFF
--- a/resources/views/components/katana/avatar-upload.blade.php
+++ b/resources/views/components/katana/avatar-upload.blade.php
@@ -50,9 +50,15 @@
 
             const reader = new FileReader();
             reader.onload = (e) => {
-                // Give the modal a tick to render before initialising Croppie
+                const imgDataUrl = e.target.result;
                 this.$nextTick(() => {
-                    setTimeout(() => {
+                    // 1. Hide spinner and SHOW the crop container first so Croppie
+                    //    can measure the element's dimensions correctly.
+                    this.loadingCrop = false;
+
+                    // 2. Wait for the DOM to reflect the visibility change,
+                    //    then init Croppie on the now-visible element.
+                    this.$nextTick(() => {
                         if (this.cropperInstance) {
                             this.cropperInstance.destroy();
                             this.cropperInstance = null;
@@ -62,9 +68,8 @@
                             boundary:   { width: 240, height: 240 },
                             enableExif: true,
                         });
-                        this.cropperInstance.bind({ url: e.target.result, orientation: 4 });
-                        this.loadingCrop = false;
-                    }, 50);
+                        this.cropperInstance.bind({ url: imgDataUrl, orientation: 4 });
+                    });
                 });
             };
             reader.readAsDataURL(file);
@@ -72,8 +77,10 @@
 
         applyCrop() {
             if (!this.cropperInstance) return;
+            // Use size:'viewport' so the result maps exactly to the 190×190
+            // circular viewport — no whitespace baked into the output image.
             this.cropperInstance
-                .result({ type: 'base64', size: { width: 400, height: 400 }, format: 'png', quality: 1 })
+                .result({ type: 'base64', size: 'viewport', format: 'png', quality: 1 })
                 .then((base64) => {
                     this.previewSrc = base64;
                     this.modalOpen = false;


### PR DESCRIPTION
Two bugs fixed:

1. Croppie was initialised while the crop container was hidden (x-show=false → display:none), so it couldn't measure the viewport dimensions. Fix: set loadingCrop=false first to show the element, then init Croppie in the next .

2. result() was called with size:{width:400,height:400} which maps to the full 240px *boundary* area (including whitespace outside the circular viewport), causing the preview to look squished/off-centre. Fix: use size:'viewport' so the output is exactly the 190x190 viewport crop with no extra whitespace.